### PR TITLE
Replace bower_components in paths

### DIFF
--- a/bower.js
+++ b/bower.js
@@ -55,6 +55,15 @@ var setPaths = function(config, bowerPath, name, main) {
 		var mainDir = getMainDir(bowerPath, name, main);
 	}
 
+	// Replace bower_components in paths to the bowerPath
+	if(bowerPath !== "bower_components") {
+		var val;
+		for(var path in config.paths) {
+			val = config.paths[path];
+			config.paths[path] = val.replace("bower_components", bowerPath);
+		}
+	}
+
 	// Set the path to the `main` and the path to the wildcard.
 	config.paths[name] = [bowerPath, name, main].join('/');
 	config.paths[name + "/*"] = mainDir + "/*.js";

--- a/test/alt_path/bower.json
+++ b/test/alt_path/bower.json
@@ -1,0 +1,9 @@
+{
+  "name": "foo",
+  "main": "foo.js",
+  "system": {
+    "paths": {
+      "bar": "bower_components/bar/bar.js"
+    }
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -20,6 +20,13 @@ asyncTest("Loads buildConfig", function(){
 	}).then(start);
 });
 
+asyncTest("Replaces bower_components path in paths", function(){
+	System.bowerPath = "vendor";
+	System.import("test/alt_path/bower.json!bower").then(function(){
+		equal(System.paths.bar, "vendor/bar/bar.js", "Correct path set");
+	}).then(start);
+});
+
 // Only run these tests for StealJS (because it requires steal syntax)
 if(System.isSteal) {
 	asyncTest("Modules with their own config works", function(){


### PR DESCRIPTION
When a library defines a path they could use bower_components to represent whatever the bowerPath is. This does substitution in the case where the user has an alternative dependency folder. Fixes #2
