### PR TITLE
Add rel_path test.

### DIFF
--- a/test/rel_path/bower.json
+++ b/test/rel_path/bower.json
@@ -1,0 +1,4 @@
+{
+	"name": "rel_path",
+	"main": "./exports.js"
+}

--- a/test/rel_path/exports.js
+++ b/test/rel_path/exports.js
@@ -1,0 +1,1 @@
+define(['./rel'], function () {})

--- a/test/test.js
+++ b/test/test.js
@@ -36,6 +36,16 @@ asyncTest("system.main overrides main", function(){
 	}).then(start);
 });
 
+asyncTest("Able to import AMD module with relative paths.", function () {
+	System.import("test/rel_path/bower.json!bower").then(function (dep) {
+		return System.import("rel_path").then(function () {
+			ok(true, "it worked");
+		});
+	}).then(start, function(err){
+		equal(err, null, "got an error");
+	});
+});
+
 QUnit.module('system-bower plugin: bowerIgnore option', {
 	setup: function() {
 		this.oldBowerPath = System.bowerPath;


### PR DESCRIPTION
rel_path test tries to import and AMD module that imports a relative module. Currently failing.

see issue #20.
